### PR TITLE
Do not disarm before arming if Alarmo is already disarmed

### DIFF
--- a/Alarmo_Keypad.yaml
+++ b/Alarmo_Keypad.yaml
@@ -184,7 +184,7 @@ action:
         - &disarm_before_arm
           if:
           - condition: template
-            value_template: '{{ "armed_" not in states[alarmo_entity_id].state }}'
+            value_template: '{{ states[alarmo_entity_id].state in ["arming", "pending", "triggered"] }}'
           then:
           - service: alarmo.disarm
             data:


### PR DESCRIPTION
Fixes behaviour in the following comment: https://github.com/array81/alarmo-keypad/issues/1#issuecomment-2493145775